### PR TITLE
fix error in export

### DIFF
--- a/backend/pdf-export-module/script/pages/meals.py
+++ b/backend/pdf-export-module/script/pages/meals.py
@@ -121,4 +121,4 @@ def add_recipe(doc, recipe):
                     if recipe['recipe_description'] != '':
                         table_content.add_row(['Beschreibung: ', recipe['recipe_description']])
                     if recipe['recipe_notes'] != '':
-                        table_content.add_row(['Notizen:', recipe['recipe_notes']])
+                        table_content.add_row(['Notizen:', recipe['recipe_notes'].strip('\n')])

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emeal/menuplanung",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "license": "MIT",
   "copyrights": "© 2019 - 2022 Cevi Züri 11 - eMeal Menüplanung",
   "scripts": {


### PR DESCRIPTION
fixes an error in the export process: if the notes contained a line break before the first or after the last word the export failed with some LaTex error:
- fixed by striping line breaks