### PR TITLE
Bug fix in export

### DIFF
--- a/backend/pdf-export-module/script/shopping_list/spelling_corrector.py
+++ b/backend/pdf-export-module/script/shopping_list/spelling_corrector.py
@@ -22,8 +22,9 @@ class SpellingCorrector:
             if correction_log is not None:
                 correction_logs.append(correction_log)
 
-        self.__db.document('sharedData/foodCategories').update(
-            {"resentCorrections": firestore.ArrayUnion(correction_logs)})
+        if correction_logs and len(correction_logs) > 0:
+            self.__db.document('sharedData/foodCategories').update(
+                {"resentCorrections": firestore.ArrayUnion(correction_logs)})
 
     def _correction(self, input_word):
         """

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emeal/menuplanung",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "license": "MIT",
   "copyrights": "© 2019 - 2022 Cevi Züri 11 - eMeal Menüplanung",
   "scripts": {

--- a/frontend/src/app/modules/change-log-module/components/version-history/version-history.component.html
+++ b/frontend/src/app/modules/change-log-module/components/version-history/version-history.component.html
@@ -6,7 +6,14 @@
     Fehlerbehebungen.
   </p>
 
-  <h3>Neues in der Version 1.14.2 (28. Juli 2022)</h3>
+  <h3>Neues in der Version 1.14.3 (1. Juli 2022)</h3>
+
+  <p class="news-element news-fixed">
+    Behebt einen Fehler beim Export: Bisher konnten Lager mit Tage ohne Rezepte nicht exportiert werden. Dies ist nun
+    ebenfalls möglich.
+  </p>
+
+  <h3>Neues in der Version 1.14.2 (28. Juni 2022)</h3>
 
   <p class="news-element news-fixed">
     Behebt einen Fehler beim Export: Zeilenumbrüche bei Rezept-Notizen führten zu Fehlern beim Export.


### PR DESCRIPTION
- [allow export of empty camps (i.g. camps without any ingredients)](https://github.com/wp99cp/eMeal_menuplanung/commit/e8829774a286d9f96a46f2b83da8dc590e84fd24)