### PR TITLE
Fix "nur Für Leitende" = 0 bug

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emeal/menuplanung",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "license": "MIT",
   "copyrights": "© 2019 - 2024 Cevi Züri 11 - eMeal Menüplanung",
   "scripts": {

--- a/frontend/src/app/modules/application-module/components/edit-recipe-in-camp/edit-recipe-in-camp.component.ts
+++ b/frontend/src/app/modules/application-module/components/edit-recipe-in-camp/edit-recipe-in-camp.component.ts
@@ -272,6 +272,7 @@ export class EditRecipeInCampComponent implements OnInit, Saveable, OnChanges {
       this.mealPart = SettingsService.calcRecipeParticipants(
         this.camp.participants,
         this.camp.vegetarians,
+        this.camp.leaders,
         this.specificMeal.participants,
         specificRecipe.participants,
         this.specificMeal.overrideParticipants,

--- a/frontend/src/app/modules/application-module/dialoges/change-log/change-log.component.html
+++ b/frontend/src/app/modules/application-module/dialoges/change-log/change-log.component.html
@@ -1,13 +1,13 @@
-<h2>Neue Versionen - v1.15.1</h2>
+<h2>Neue Versionen - v1.15.2</h2>
 
 <div mat-dialog-content>
 
   <h3>Was gibt es neues in eMeal - Menüplanung? </h3>
 
-  <p>Dieses Update fügt Neues hinzu:</p>
+  <p>Dieses Update behebt einen Fehler:</p>
 
-  <p class="news-element news-feature">
-    Neuerdings gibt es auch den Menu-Typ "Dessert".
+  <p class="news-element news-fixed">
+    Bisher hat das Berechnen einer Mahlzeit nur für Leiter*innen nicht funktioniert. Dieser Fehler wurde behoben.
   </p>
 
 </div>

--- a/frontend/src/app/modules/application-module/dialoges/recipe-info/recipe-info.component.html
+++ b/frontend/src/app/modules/application-module/dialoges/recipe-info/recipe-info.component.html
@@ -26,6 +26,7 @@
       {{calcRecipeParticipants(
       camp.participants,
       camp.vegetarians,
+      camp.leaders,
       specificMeal.participants,
       this.recipeForm.get('overrideParticipants').value,
       specificMeal.overrideParticipants,

--- a/frontend/src/app/modules/application-module/services/settings.service.ts
+++ b/frontend/src/app/modules/application-module/services/settings.service.ts
@@ -54,6 +54,7 @@ export class SettingsService {
   public static calcRecipeParticipants(
     campPart: number,
     campVegis: number,
+    campLeaders: number,
     mealPart: number,
     recipePart: number,
     mealOver: boolean,
@@ -74,7 +75,7 @@ export class SettingsService {
 
     } else if (vegiState === 'leaders') {
 
-      return 0;
+      return campLeaders;
     }
 
     return calcRecipePart;

--- a/frontend/src/app/modules/change-log-module/components/version-history/version-history.component.html
+++ b/frontend/src/app/modules/change-log-module/components/version-history/version-history.component.html
@@ -6,6 +6,13 @@
     Fehlerbehebungen.
   </p>
 
+  <h3>Neues in der Version 1.15.2 (1. Mai 2024)</h3>
+
+  <p class="news-element news-fixed">
+  Bisher hat das Berechnen einer Mahlzeit nur für Leiter*innen nicht funktioniert. Dieser Fehler wurde behoben.
+  </p>
+
+
   <h3>Neues in der Version 1.15.1 (1. Mai 2024)</h3>
 
   <p class="news-element news-feature">


### PR DESCRIPTION
This is only a frontend bug. Computing the data in the export works just fine.

Thanks @maede97, see https://github.com/wp99cp/eMeal_menuplanung/pull/225#issue-2273620577